### PR TITLE
Added commands to allow admins to view/teleport to other player's homes.

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbessentials/config/FTBEConfig.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/config/FTBEConfig.java
@@ -63,6 +63,8 @@ public interface FTBEConfig {
 			.comment("Allows admins to view other users' inventories using a command");
 	ToggleableConfig MUTE = new ToggleableConfig(ADMIN, "mute") // todo: temp mute?
 			.comment("Allows admins to restrict players from chatting by using a command to mute (or unmute) them");
+	ToggleableConfig HOME_FOR = new ToggleableConfig(ADMIN, "homefor")
+			.comment("Allows admins to view and teleport to other users' homes");
 
 	SNBTConfig MISC = CONFIG.getGroup("misc").comment("Miscellaneous features and utilities");
 	ToggleableConfig KICKME = new ToggleableConfig(MISC, "kickme")


### PR DESCRIPTION
Added admin commands /homefor and /listhomesfor to allow teleporting and viewing other player's homes. This also has offline support so admins can view offline player's homes too.

Examples:
`/homefor steve home1` Teleports you to steve's home1.
`/homefor steve` Shows a list of steve's homes.
`/listhomesfor steve` Shows a list of steve's homes.