### PR TITLE
[1.18] feat: add luckperms integration with meta

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,8 @@ dependencies {
 	}
 
 	modImplementation "dev.ftb.mods:ftb-ranks-forge:${rootProject.ftb_ranks_version}"
+
+	compileOnly 'net.luckperms:api:5.4'
 }
 
 processResources {

--- a/src/main/java/dev/ftb/mods/ftbessentials/FTBEssentials.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/FTBEssentials.java
@@ -24,11 +24,13 @@ public class FTBEssentials {
 
 	public static FTBEssentialsCommon PROXY;
 	public static boolean ranksMod;
+	public static boolean luckpermsMod;
 
 	public FTBEssentials() {
 		ModLoadingContext.get().registerExtensionPoint(DisplayTest.class, () -> new DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));
 		FTBEssentialsNet.init();
 		PROXY = DistExecutor.safeRunForDist(() -> FTBEssentialsClient::new, () -> FTBEssentialsCommon::new);
 		ranksMod = ModList.get().isLoaded(FTBRanks.MOD_ID);
+		luckpermsMod = ModList.get().isLoaded("luckperms");
 	}
 }

--- a/src/main/java/dev/ftb/mods/ftbessentials/LuckPermsIntegration.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/LuckPermsIntegration.java
@@ -1,0 +1,30 @@
+package dev.ftb.mods.ftbessentials;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.model.user.User;
+import net.luckperms.api.query.QueryOptions;
+import net.minecraft.server.level.ServerPlayer;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public class LuckPermsIntegration {
+
+    public static int getInt(ServerPlayer player, int def, String node){
+        return Math.max(getMetaData(player.getUUID(), node).map(Integer::parseInt).orElse(def), 0);
+    }
+
+    private static Optional<String> getMetaData(UUID uuid, String meta){
+        LuckPerms luckperms = LuckPermsProvider.get();
+        Optional<String> metaValue = Optional.empty();
+        User user = luckperms.getUserManager().getUser(uuid);
+        if(user != null){
+            Optional<QueryOptions> context = luckperms.getContextManager().getQueryOptions(user);
+            if(context.isPresent()){
+                metaValue = Optional.ofNullable(user.getCachedData().getMetaData(context.get()).getMetaValue(meta));
+            }
+        }
+        return metaValue;
+    }
+}

--- a/src/main/java/dev/ftb/mods/ftbessentials/LuckPermsIntegration.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/LuckPermsIntegration.java
@@ -18,12 +18,17 @@ public class LuckPermsIntegration {
     private static Optional<String> getMetaData(UUID uuid, String meta){
         LuckPerms luckperms = LuckPermsProvider.get();
         Optional<String> metaValue = Optional.empty();
-        User user = luckperms.getUserManager().getUser(uuid);
-        if(user != null){
-            Optional<QueryOptions> context = luckperms.getContextManager().getQueryOptions(user);
-            if(context.isPresent()){
-                metaValue = Optional.ofNullable(user.getCachedData().getMetaData(context.get()).getMetaValue(meta));
+        try {
+            User user = luckperms.getUserManager().getUser(uuid);
+            if(user != null){
+                Optional<QueryOptions> context = luckperms.getContextManager().getQueryOptions(user);
+                if(context.isPresent()){
+                    metaValue = Optional.ofNullable(user.getCachedData().getMetaData(context.get()).getMetaValue(meta));
+                }
             }
+        } catch (IllegalStateException e){
+            System.err.println("Error on fetching user with luckperms");
+            System.err.println(e.getMessage());
         }
         return metaValue;
     }

--- a/src/main/java/dev/ftb/mods/ftbessentials/config/PermissionBasedIntValue.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/config/PermissionBasedIntValue.java
@@ -2,6 +2,7 @@ package dev.ftb.mods.ftbessentials.config;
 
 import dev.ftb.mods.ftbessentials.FTBEssentials;
 import dev.ftb.mods.ftbessentials.FTBRanksIntegration;
+import dev.ftb.mods.ftbessentials.LuckPermsIntegration;
 import dev.ftb.mods.ftblibrary.snbt.config.IntValue;
 import net.minecraft.server.level.ServerPlayer;
 
@@ -19,6 +20,8 @@ public class PermissionBasedIntValue {
 	public int get(ServerPlayer player) {
 		if (FTBEssentials.ranksMod) {
 			return FTBRanksIntegration.getInt(player, value.get(), permission);
+		} else if (FTBEssentials.luckpermsMod) {
+			return LuckPermsIntegration.getInt(player, value.get(), permission);
 		}
 
 		return value.get();

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -39,3 +39,10 @@ mandatory = false
 versionRange = "[1801.1.6-build.18,)"
 ordering = "AFTER"
 side = "BOTH"
+
+[[dependencies.ftbessentials]]
+modId = "luckperms"
+mandatory = false
+versionRange = "[5.4.30,)"
+ordering = "AFTER"
+side = "SERVER"


### PR DESCRIPTION
Add support for luckperms metadata.

I use the same approach as you with ftbranks but i did it with luckperms.

Same stuff has i did in : https://github.com/FTBTeam/FTB-Chunks/pull/214