### PR TITLE
1.19/dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1902.3.0]
+## [1902.3.1]
 
 ### Added
 * Fabric support: FTB Essentials is now a cross-platform mod!
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The /mute command can now take an optional duration, which is a number followed by one of 's','m','h','d' or 'w'
   * E.g. `/mute badguy 10m` or `/mute badguy 1.5h`
   * Mutes with no duration are permanent until reversed with the `/unmute` command, as before
+
+## [1902.3.0]
+
+### Added
+* _Skipped_
 
 ## [1902.2.0]
 

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -56,6 +56,7 @@ remapJar {
     injectAccessWidener = true
     input.set shadowJar.archiveFile
     dependsOn shadowJar
+    archiveBaseName.set "${rootProject.archives_base_name}-${project.name}"
     classifier null
 }
 

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -73,6 +73,7 @@ shadowJar {
 remapJar {
     input.set shadowJar.archiveFile
     dependsOn shadowJar
+    archiveBaseName.set "${rootProject.archives_base_name}-${project.name}"
     classifier null
 }
 
@@ -131,6 +132,7 @@ if (ENV.CURSEFORGE_KEY) {
             id = project.curseforge_id
             releaseType = project.curseforge_type
             addGameVersion project.minecraft_version
+            addGameVersion "Forge"
             mainArtifact(remapJar.archiveFile)
             relations {
                 requiredDependency 'ftb-library-forge'

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,4 +17,4 @@ fabric_loader_version=0.14.9
 fabric_api_version=0.60.0+1.19.2
 # common curseforge project for forge and fabric
 curseforge_id=410811
-curseforge_type=release
+curseforge_type=beta

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ mod_id=ftbessentials
 archives_base_name=ftb-essentials
 maven_group=dev.ftb.mods
 minecraft_version=1.19.2
-mod_version=1902.3.0
+mod_version=1902.3.1
 mod_author=FTB Team
 
 ftb_library_version=1902.3.16-build.191


### PR DESCRIPTION
To be merged once the previous builds deleted from CF.  Fixes the JAR filenames, adding -forge and -fabric to them. Also ensure Forge build is tagged with game version "Forge".