### PR TITLE
Add Dimension Teleport Blacklist

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbessentials/FTBEEventHandler.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/FTBEEventHandler.java
@@ -35,6 +35,7 @@ import net.minecraftforge.server.ServerLifecycleHooks;
 
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.regex.Pattern;
 
 /**
  * @author LatvianModder
@@ -76,6 +77,10 @@ public class FTBEEventHandler {
 		} catch (Exception ex) {
 			FTBEssentials.LOGGER.error("Failed to load world data: " + ex);
 			ex.printStackTrace();
+		}
+
+		for(String s : FTBEConfig.DISALLOWED_DIMENSION_PATTERNS.get()) {
+			FTBEssentials.DISALLOWED_DIMENSION_PATTERNS.add(Pattern.compile(s));
 		}
 	}
 

--- a/src/main/java/dev/ftb/mods/ftbessentials/FTBEssentials.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/FTBEssentials.java
@@ -12,6 +12,10 @@ import net.minecraftforge.network.NetworkConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
 /**
  * @author LatvianModder
  */
@@ -24,6 +28,8 @@ public class FTBEssentials {
 	public static FTBEssentialsCommon PROXY;
 	public static boolean ranksMod;
 	public static boolean luckpermsMod;
+
+	public static List<Pattern> DISALLOWED_DIMENSION_PATTERNS = new ArrayList<>();
 
 	public FTBEssentials() {
 		ModLoadingContext.get().registerExtensionPoint(DisplayTest.class, () -> new DisplayTest(() -> NetworkConstants.IGNORESERVERONLY, (a, b) -> true));

--- a/src/main/java/dev/ftb/mods/ftbessentials/config/FTBEConfig.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/config/FTBEConfig.java
@@ -3,6 +3,9 @@ package dev.ftb.mods.ftbessentials.config;
 import dev.ftb.mods.ftbessentials.FTBEssentials;
 import dev.ftb.mods.ftblibrary.snbt.config.IntValue;
 import dev.ftb.mods.ftblibrary.snbt.config.SNBTConfig;
+import dev.ftb.mods.ftblibrary.snbt.config.StringListValue;
+
+import java.util.List;
 
 /**
  * @author LatvianModder
@@ -79,4 +82,7 @@ public interface FTBEConfig {
 			.comment("Allows users to access their ender chest, as well as admins to manage other players' ender chests.");
 	ToggleableConfig LEADERBOARD = new ToggleableConfig(MISC, "leaderboard")
 			.comment("Allows users to view player leaderboard stats.");
+
+	StringListValue DISALLOWED_DIMENSION_PATTERNS = MISC.getStringList("disallowed_dimensions", List.of(new String[]{""}))
+			.comment("List of REGEX patterns matching dimensions teleports are restricted to.");
 }

--- a/src/main/java/dev/ftb/mods/ftbessentials/util/FTBEPlayerData.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/util/FTBEPlayerData.java
@@ -19,6 +19,7 @@ import net.minecraft.world.level.Level;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * @author LatvianModder
@@ -168,6 +169,12 @@ public class FTBEPlayerData {
 	}
 
 	public void addTeleportHistory(ServerPlayer player, TeleportPos pos) {
+		for (Pattern p : FTBEssentials.DISALLOWED_DIMENSION_PATTERNS) {
+			if(p.matcher(pos.dimension.location().getPath()).matches()) {
+				return;
+			}
+		}
+
 		teleportHistory.add(pos);
 
 		while (teleportHistory.size() > FTBEConfig.MAX_BACK.get(player)) {

--- a/src/main/java/dev/ftb/mods/ftbessentials/util/TeleportPos.java
+++ b/src/main/java/dev/ftb/mods/ftbessentials/util/TeleportPos.java
@@ -1,5 +1,7 @@
 package dev.ftb.mods.ftbessentials.util;
 
+import dev.ftb.mods.ftbessentials.FTBEssentials;
+import dev.ftb.mods.ftbessentials.config.FTBEConfig;
 import dev.ftb.mods.ftblibrary.snbt.SNBTCompoundTag;
 import dev.ftb.mods.ftblibrary.util.TimeUtils;
 import net.minecraft.core.BlockPos;
@@ -12,6 +14,8 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.level.Level;
+
+import java.util.regex.Pattern;
 
 /**
  * @author LatvianModder
@@ -35,6 +39,12 @@ public class TeleportPos {
 			player.displayClientMessage(new TextComponent("Dimension not found!"), false);
 			return 0;
 		};
+
+		TeleportResult DIMENSION_NOT_ALLOWED = player -> {
+			player.displayClientMessage(new TextComponent("Teleportation to this dimension is not allowed!"), false);
+			return 0;
+		};
+
 
 		int runCommand(ServerPlayer player);
 
@@ -89,6 +99,12 @@ public class TeleportPos {
 	}
 
 	public TeleportResult teleport(ServerPlayer player) {
+		for (Pattern p : FTBEssentials.DISALLOWED_DIMENSION_PATTERNS) {
+			if(p.matcher(dimension.location().getPath()).matches()) {
+				return TeleportResult.DIMENSION_NOT_ALLOWED;
+			}
+		}
+
 		ServerLevel world = player.server.getLevel(dimension);
 
 		if (world == null) {


### PR DESCRIPTION
Added blacklist for teleportation between dimensions.

This was created for use with the Vault Hunters modpack in order to prevent users from using /back to return to failed vaults after they had been offloaded.

This could have applications elsewhere and I am open to suggestions for improvement.