### PR TITLE
Reimplemented Dimension Blacklists for 1.21

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbessentials/commands/groups/TeleportingCommands.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/commands/groups/TeleportingCommands.java
@@ -110,7 +110,7 @@ public class TeleportingCommands {
 
     //#region RTP
     private static int rtp(ServerPlayer player) {
-        if (!player.hasPermissions(2) && !DimensionFilter.isDimensionOK(player.level().dimension())) {
+        if (!player.hasPermissions(2) && !DimensionFilter.isRtpDimensionOK(player.level().dimension())) {
             player.displayClientMessage(Component.literal("You may not use /rtp in this dimension!").withStyle(ChatFormatting.RED), false);
             return 0;
         }

--- a/common/src/main/java/dev/ftb/mods/ftbessentials/config/FTBEConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/config/FTBEConfig.java
@@ -71,6 +71,14 @@ public interface FTBEConfig {
 			.comment("Allows admins to teleport to dimension");
 	ToggleableConfig JUMP = new ToggleableConfig(TELEPORTATION, "jump")
 			.comment("Allows admins to jump (teleport) to the focused block");
+	
+	SNBTConfig TELEPORTATION_BLACKLISTS = TELEPORTATION.addGroup("blacklists")
+			.comment("Blacklists for all teleport commands",
+			"Wildcarded dimensions (e.g. 'somemod:*') are supported");
+	StringListValue TELEPORTATION_BLACKLIST_FROM = TELEPORTATION_BLACKLISTS.addStringList("from", List.of())
+			.comment("Dimensions players aren't permitted to run teleport commands in.");
+	StringListValue TELEPORTATION_BLACKLIST_TO = TELEPORTATION_BLACKLISTS.addStringList("to", List.of())
+			.comment("Dimensions players aren't permitted to teleport into.");
 
 	SNBTConfig ADMIN = CONFIG.addGroup("admin").comment("Admin commands for cheating and moderation");
 	ToggleableConfig HEAL = new ToggleableConfig(ADMIN, "heal")

--- a/common/src/main/java/dev/ftb/mods/ftbessentials/util/DimensionFilter.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/util/DimensionFilter.java
@@ -11,31 +11,61 @@ import java.util.Set;
 import java.util.function.Predicate;
 
 public class DimensionFilter {
-    private static WildcardedRLMatcher dimensionMatcherB = null;
-    private static WildcardedRLMatcher dimensionMatcherW = null;
+    private static WildcardedRLMatcher rtpDimensionMatcherB = null;
+    private static WildcardedRLMatcher rtpDimensionMatcherW = null;
 
-    public static boolean isDimensionOK(ResourceKey<Level> levelKey) {
+    private static WildcardedRLMatcher allDimensionMatcherBTo = null;
+    private static WildcardedRLMatcher allDimensionMatcherBFrom = null;
+
+    public static boolean isRtpDimensionOK(ResourceKey<Level> levelKey) {
         ResourceLocation name = levelKey.location();
-        return !getDimensionBlacklist().test(name) && (getDimensionWhitelist().isEmpty() || getDimensionWhitelist().test(name));
+        return !getRtpDimensionBlacklist().test(name) && (getRtpDimensionWhitelist().isEmpty() || getRtpDimensionWhitelist().test(name));
+    }
+    
+    public static boolean isDimensionOKFrom(ResourceKey<Level> levelKey) {
+        ResourceLocation name = levelKey.location();
+        return !getAllCommandDimensionBlacklistFrom().test(name);
     }
 
-    private static WildcardedRLMatcher getDimensionWhitelist() {
-        if (dimensionMatcherW == null) {
-            dimensionMatcherW = new WildcardedRLMatcher(FTBEConfig.RTP_DIMENSION_WHITELIST.get());
+    public static boolean isDimensionOKTo(ResourceKey<Level> levelKey) {
+        ResourceLocation name = levelKey.location();
+        return !getAllCommandDimensionBlacklistTo().test(name);
+    }
+
+    private static WildcardedRLMatcher getRtpDimensionWhitelist() {
+        if (rtpDimensionMatcherW == null) {
+            rtpDimensionMatcherW = new WildcardedRLMatcher(FTBEConfig.RTP_DIMENSION_WHITELIST.get());
         }
-        return dimensionMatcherW;
+        return rtpDimensionMatcherW;
     }
 
-    private static WildcardedRLMatcher getDimensionBlacklist() {
-        if (dimensionMatcherB == null) {
-            dimensionMatcherB = new WildcardedRLMatcher(FTBEConfig.RTP_DIMENSION_BLACKLIST.get());
+    private static WildcardedRLMatcher getRtpDimensionBlacklist() {
+        if (rtpDimensionMatcherB == null) {
+            rtpDimensionMatcherB = new WildcardedRLMatcher(FTBEConfig.RTP_DIMENSION_BLACKLIST.get());
         }
-        return dimensionMatcherB;
+        return rtpDimensionMatcherB;
     }
-
+    
+    private static WildcardedRLMatcher getAllCommandDimensionBlacklistFrom() {
+        if (allDimensionMatcherBFrom == null) {
+            allDimensionMatcherBFrom = new WildcardedRLMatcher(FTBEConfig.TELEPORTATION_BLACKLIST_FROM.get());
+        }
+        return allDimensionMatcherBFrom;
+    }
+    
+    private static WildcardedRLMatcher getAllCommandDimensionBlacklistTo() {
+        if (allDimensionMatcherBTo == null) {
+            allDimensionMatcherBTo = new WildcardedRLMatcher(FTBEConfig.TELEPORTATION_BLACKLIST_TO.get());
+        }
+        return allDimensionMatcherBTo;
+    }
+    
     public static void clearMatcherCaches() {
-        dimensionMatcherB = null;
-        dimensionMatcherW = null;
+        rtpDimensionMatcherB = null;
+        rtpDimensionMatcherW = null;
+        
+        allDimensionMatcherBFrom = null;
+        allDimensionMatcherBTo = null;
     }
 
     private static class WildcardedRLMatcher implements Predicate<ResourceLocation> {

--- a/common/src/main/java/dev/ftb/mods/ftbessentials/util/TeleportPos.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/util/TeleportPos.java
@@ -11,6 +11,7 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 
 public class TeleportPos {
@@ -45,6 +46,15 @@ public class TeleportPos {
 		this.yRot = (tag.getTagType("yRot") == CompoundTag.TAG_FLOAT) ? tag.getFloat("yRot") : null;
 		this.xRot = (tag.getTagType("xRot") == CompoundTag.TAG_FLOAT) ? tag.getFloat("xRot") : null;
 		time = tag.getLong("time");
+	}
+
+	public TeleportResult checkDimensionBlacklist(Player player) {
+		if (!DimensionFilter.isDimensionOKTo(this.dimension)) {
+			return TeleportResult.DIMENSION_NOT_ALLOWED_TO;
+		} else if(!DimensionFilter.isDimensionOKFrom(player.level().dimension())) {
+			return TeleportResult.DIMENSION_NOT_ALLOWED_FROM;
+		}
+		return TeleportResult.SUCCESS;
 	}
 
 	public TeleportResult teleport(ServerPlayer player) {
@@ -128,6 +138,10 @@ public class TeleportPos {
 		TeleportResult DIMENSION_NOT_FOUND = failed(Component.literal("Dimension not found!"));
 
 		TeleportResult UNKNOWN_DESTINATION = failed(Component.literal("Unknown destination!"));
+		
+		TeleportResult DIMENSION_NOT_ALLOWED_FROM = failed(Component.literal("Teleportation from your dimension is not allowed!"));
+		
+		TeleportResult DIMENSION_NOT_ALLOWED_TO = failed(Component.literal("Teleportation to this dimension is not allowed!"));
 
 		int runCommand(ServerPlayer player);
 

--- a/common/src/main/java/dev/ftb/mods/ftbessentials/util/WarmupCooldownTeleporter.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/util/WarmupCooldownTeleporter.java
@@ -61,12 +61,18 @@ public class WarmupCooldownTeleporter {
 			return cooldownResult;
 		}
 
+		TeleportPos pos = positionGetter.apply(player);
+
+		TeleportResult blacklistedResult = pos.checkDimensionBlacklist(player);
+		if (!blacklistedResult.isSuccess()) {
+			return blacklistedResult;
+		}
+		
 		CompoundEventResult<Component> result = TeleportEvent.TELEPORT.invoker().teleport(player);
 		if (result.isFalse()) {
 			return TeleportResult.failed(result.object());
 		}
-
-		TeleportPos pos = positionGetter.apply(player);
+		
 		if (!firePlatformTeleportEvent(player, Vec3.atBottomCenterOf(pos.getPos()))) {
 			return TeleportResult.failed(Component.translatable("ftbessentials.teleport_prevented"));
 		}


### PR DESCRIPTION
Implement Dimension Blacklists for teleporting to and from dimensions.

These blacklists apply for all commands that use the `teleport` method inside of `WarmupCooldownTeleporter` (/home, /tpa, /back, etc)

Changes compared to 1.18 implementation:
- Moved from Regex Patterns to WildcardedRLMatchers for dimension blacklists
- Added a teleport from blacklist
- Improved code quality