### PR TITLE
Implement RTP minimum and maximum distance arguments

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbessentials/config/FTBEConfig.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/config/FTBEConfig.java
@@ -63,6 +63,18 @@ public interface FTBEConfig {
 	StringListValue RTP_DIMENSION_BLACKLIST = RTP.config.addStringList("dimension_blacklist", List.of("minecraft:the_end"))
 			.comment("Blacklisted dimension ID's for /rtp (player *must not* be in any of these dimensions)",
 					"Wildcarded dimensions (e.g. 'somemod:*') are supported");
+
+	PermissionBasedBooleanValue RTP_MAX_DISTANCE_CUSTOM = new PermissionBasedBooleanValue(
+			RTP.config.addBoolean("allow_custom_max_distance", false),
+			"ftbessentials.rtp.custom_max",
+			"Allow player to specify (only) custom max distance in rtp command"
+	);
+	
+	PermissionBasedBooleanValue RTP_MIN_DISTANCE_CUSTOM = new PermissionBasedBooleanValue(
+			RTP.config.addBoolean("allow_custom_min_max_distance", false),
+			"ftbessentials.rtp.custom_min_max",
+			"Allow player to specify custom min and max distance in rtp command"
+	);
 	// tpl
 	ToggleableConfig TPL = new ToggleableConfig(TELEPORTATION, "tpl")
 			.comment("Allows admins to teleport to the location a user was last seen at");

--- a/common/src/main/java/dev/ftb/mods/ftbessentials/config/PermissionBasedBooleanValue.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/config/PermissionBasedBooleanValue.java
@@ -1,0 +1,22 @@
+package dev.ftb.mods.ftbessentials.config;
+
+import dev.ftb.mods.ftbessentials.integration.PermissionsHelper;
+import dev.ftb.mods.ftblibrary.snbt.config.BooleanValue;
+import net.minecraft.server.level.ServerPlayer;
+
+public class PermissionBasedBooleanValue {
+	public final BooleanValue value;
+	public final String permission;
+
+	public PermissionBasedBooleanValue(BooleanValue value, String permission, String... comment) {
+		this.value = value
+				.comment(comment)
+				.comment("You can override this with FTB Ranks using " + permission);
+		this.permission = permission;
+	}
+
+	public boolean get(ServerPlayer player) {
+		return PermissionsHelper.getInstance().getBool(player, value.get(), permission);
+	}
+
+}

--- a/common/src/main/java/dev/ftb/mods/ftbessentials/integration/FTBRanksIntegration.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/integration/FTBRanksIntegration.java
@@ -7,4 +7,8 @@ public class FTBRanksIntegration implements PermissionsProvider {
 	public int getInt(ServerPlayer player, int def, String node) {
 		return Math.max(FTBRanksAPI.getPermissionValue(player, node).asInteger().orElse(def), 0);
 	}
+
+	public boolean getBool(ServerPlayer player, boolean def, String node) {
+		return FTBRanksAPI.getPermissionValue(player, node).asBoolean().orElse(def);
+	}
 }

--- a/common/src/main/java/dev/ftb/mods/ftbessentials/integration/LuckPermsIntegration.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/integration/LuckPermsIntegration.java
@@ -13,6 +13,10 @@ public class LuckPermsIntegration implements PermissionsProvider {
     public int getInt(ServerPlayer player, int def, String node) {
         return Math.max(getMetaData(player.getUUID(), node).map(Integer::parseInt).orElse(def), 0);
     }
+    
+    public boolean getBool(ServerPlayer player, boolean def, String node) {
+        return getMetaData(player.getUUID(), node).map(Boolean::parseBoolean).orElse(def);
+    }
 
     private static Optional<String> getMetaData(UUID uuid, String meta) {
         LuckPerms luckperms = LuckPermsProvider.get();

--- a/common/src/main/java/dev/ftb/mods/ftbessentials/integration/PermissionsProvider.java
+++ b/common/src/main/java/dev/ftb/mods/ftbessentials/integration/PermissionsProvider.java
@@ -6,4 +6,8 @@ public interface PermissionsProvider {
     default int getInt(ServerPlayer player, int def, String node) {
         return def;
     }
+    
+    default boolean getBool(ServerPlayer player, boolean def, String node) {
+        return def;
+    }
 }


### PR DESCRIPTION
Implemented from suggestion at FTBTeam/FTB-Mods-Issues#1138

Update the RTP command to allow for user definable minimum and maximum distances

- Use permissions to allow the arguments
  - ftbessentials.rtp.custom_max : Allow setting only the maximum distance
  - ftbessentials.rtp.custom_min_max : Allow setting the minimum and maximum distance
- Add PermissionBasedBooleanValue for boolean integration with LuckPerms and FTBRanks
  - LuckPerms is non-functional on NeoForge only (see LuckPerms/LuckPerms#3963), this was fixed in LuckPerms for 1.21.3+, however it is unsure if there are plans to backport these changes